### PR TITLE
Add bytes method

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ print(v) -- 0.35999271506444
 ```
 
 
+## s = sfmt.bytes( len )
+
+generates a pseudo-random byte string.
+
+**Parameters**
+
+- `len:integer`: length of the byte string.
+
+**Returns**
+
+- `s:string`: a pseudo-random byte string of the specified length.
+
+
 ## sfmt.init( [seed, ...] )
 
 initializes the default generator with an unsigned 32bit integer seed value.

--- a/src/sfmt.c
+++ b/src/sfmt.c
@@ -98,6 +98,33 @@ static inline lua_sfmt_t *checksfmt(lua_State *L, randbit_t bit)
     return s;
 }
 
+static int bytes_lua(lua_State *L)
+{
+    lua_sfmt_t *s = checksfmt(L, RANDBIT_UINT64);
+    size_t len    = lauxh_checkunsigned(L, 2);
+    luaL_Buffer b;
+
+    luaL_buffinit(L, &b);
+    while (len >= 8) {
+        uint64_t v = sfmt_genrand_uint64(&s->sfmt);
+        luaL_addlstring(&b, (const char *)&v, sizeof(v));
+        len -= 8;
+    }
+    if (len > 0) {
+        uint64_t v = sfmt_genrand_uint64(&s->sfmt);
+        luaL_addlstring(&b, (const char *)&v, len);
+    }
+    luaL_pushresult(&b);
+    return 1;
+}
+
+static int default_bytes_lua(lua_State *L)
+{
+    lauxh_pushref((L), DEFAULT_SFMT_REF);
+    lua_insert(L, 1);
+    return bytes_lua(L);
+}
+
 static const lua_Number LUA_SFMT_NUMMAX =
     std::numeric_limits<lua_Number>::max();
 
@@ -359,6 +386,7 @@ LUALIB_API int luaopen_sfmt(lua_State *L)
             {"real3",    real3_lua   },
             {"res53",    res53_lua   },
             {"res53mix", res53mix_lua},
+            {"bytes",    bytes_lua   },
             {NULL,       NULL        }
         };
 
@@ -393,6 +421,7 @@ LUALIB_API int luaopen_sfmt(lua_State *L)
     lauxh_pushfn2tbl(L, "real3", default_real3_lua);
     lauxh_pushfn2tbl(L, "res53", default_res53_lua);
     lauxh_pushfn2tbl(L, "res53mix", default_res53mix_lua);
+    lauxh_pushfn2tbl(L, "bytes", default_bytes_lua);
     lauxh_pushfn2tbl(L, "new", new_lua);
 
     return 1;

--- a/test/sfmt_test.lua
+++ b/test/sfmt_test.lua
@@ -217,3 +217,26 @@ function testcase.res53mix()
     end
 end
 
+function testcase.bytes()
+    -- test that generate random bytes
+    sfmt.init(TEST_SEED)
+    local v = sfmt.bytes(10)
+    local s = assert(sfmt.new(TEST_SEED))
+    assert.equal(s:bytes(10), v)
+    assert.is_string(v)
+    assert.equal(#v, 10)
+
+    -- test that generate random bytes with length 0
+    local b = s:bytes(0)
+    assert.is_string(b)
+    assert.equal(#b, 0)
+
+    -- test that throws error if length is not a number
+    local err = assert.throws(s.bytes, s)
+    assert.re_match(err, 'bad argument.+unsigned number expected')
+
+    -- test that throws error if length is negative number
+    err = assert.throws(s.bytes, s, -1)
+    assert.re_match(err, 'bad argument.+unsigned number expected')
+end
+


### PR DESCRIPTION
This pull request introduces a new feature to generate pseudo-random byte strings in the `sfmt` library. It includes updates to the library's API, documentation, and test suite to support this functionality.

### Feature Addition: Pseudo-Random Byte String Generation

#### Code Changes:
* Added `bytes_lua` and `default_bytes_lua` functions to generate pseudo-random byte strings in the `src/sfmt.c` file. These functions handle the logic for creating byte strings of specified lengths.
* Registered the `bytes` function in the library's API by updating the `luaopen_sfmt` function, enabling users to access the new feature. [[1]](diffhunk://#diff-841416d9254f2333ec46d333912405a9b284628032c796c7d25e9be282cd8c94R389) [[2]](diffhunk://#diff-841416d9254f2333ec46d333912405a9b284628032c796c7d25e9be282cd8c94R424)

#### Documentation Updates:
* Updated the `README.md` file to include documentation for the new `sfmt.bytes(len)` function. This section describes the parameters, return value, and usage of the function.

#### Test Suite Enhancements:
* Added a new test case, `testcase.bytes`, in `test/sfmt_test.lua` to verify the correctness of the `sfmt.bytes` function. The tests cover various scenarios, including valid input, edge cases (e.g., length 0), and error handling for invalid inputs.